### PR TITLE
Update JSQSystemSoundPlayer+JSQMessages.m

### DIFF
--- a/JSQMessagesViewController/Categories/JSQSystemSoundPlayer+JSQMessages.m
+++ b/JSQMessagesViewController/Categories/JSQSystemSoundPlayer+JSQMessages.m
@@ -62,10 +62,10 @@ static NSString * const kJSQMessageSentSoundName = @"message_sent";
     NSString *fileName = [NSString stringWithFormat:@"JSQMessagesAssets.bundle/Sounds/%@", soundName];
     
     if (asAlert) {
-        [[JSQSystemSoundPlayer sharedPlayer] playAlertSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF];
-    }
-    else {
-        [[JSQSystemSoundPlayer sharedPlayer] playSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF];
+        [[JSQSystemSoundPlayer sharedPlayer] playAlertSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF completion:nil];
+        
+    } else {
+        [[JSQSystemSoundPlayer sharedPlayer] playSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF completion:nil];
     }
     
     //  restore original bundle


### PR DESCRIPTION
Old code:

```
if (asAlert) {
    [[JSQSystemSoundPlayer sharedPlayer] playAlertSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF];
}
else {
    [[JSQSystemSoundPlayer sharedPlayer] playSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF];
}
```

threw error:

```
No visible @interface for 'JSQSystemSoundPlayer' declares the selector 'playAlertSoundWithFilename:fileExtension:'
```

Added completion handler: "completion: nil" to resolve this error. Error arose while working from Xcode 7.2, iOS 9.2, Swift 2.1, would not compile. Compiles fine after adding completion handler.
